### PR TITLE
Prevent data loss from fast subsequent updates

### DIFF
--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -23,6 +23,11 @@ export function getData() {
 }
 
 export async function setData(data) {
+  if (!data || Object.keys(data).length === 0) {
+    console.warn(`${MODULE_ID} | Attempted to set empty/invalid data, aborting`, data);
+    return;
+  }
+  
   _dataCache = data;
   
   if (!game.user.isGM) {

--- a/src/scripts/hooks.js
+++ b/src/scripts/hooks.js
@@ -1,5 +1,5 @@
 import { MODULE_ID, DEFAULT_SETTINGS, DEFAULT_DATA } from './constants.js';
-import { getSettings, handleSocketMessage, getData, setData } from './data.js';
+import { getSettings, handleSocketMessage, getData, setData, invalidateCache } from './data.js';
 import { ReputationEvents } from './events.js';
 import { ReputationSettingsApp } from './apps/ReputationSettingsApp.js';
 import { RelationsViewerApp } from './apps/RelationsViewerApp.js';
@@ -11,6 +11,13 @@ import { getTracked, addTracked, removeTracked, getDisplayName, getPCs, isPlayer
 import { getFactions, getFaction, addFaction, deleteFaction, addFactionMember, removeFactionMember } from './core/factions.js';
 import { getLocations, getLocation, addLocation, deleteLocation } from './core/locations.js';
 import { getTiers, getTier } from './data.js';
+
+// Settings that are managed by this module's internal save mechanism and don't require cache invalidation
+const CACHE_MANAGED_SETTINGS = new Set([
+  'reputationData',
+  'reputationSettings',
+  'relationTiers'
+]);
 
 export function openRelationsViewer() {
   new RelationsViewerApp().render(true);
@@ -194,7 +201,13 @@ export function registerHooks() {
   });
 
   Hooks.on('updateSetting', setting => {
-    if (setting.key?.startsWith(`${MODULE_ID}.`)) import('./data.js').then(m => m.invalidateCache());
+    const key = setting.key || '';
+    if (key.startsWith(`${MODULE_ID}.`)) {
+      const settingName = key.slice(MODULE_ID.length + 1);
+      if (settingName && !CACHE_MANAGED_SETTINGS.has(settingName)) {
+        invalidateCache();
+      }
+    }
   });
 
   Hooks.on('getSceneControlButtons', controls => {


### PR DESCRIPTION
When my group was experimenting with this module for our server, we kept having it wipe data.  Looks like there's a race condition that would sometimes invalidate the cache when the module was mid-save, leading to all the faction tracking data occasionally getting overwritten with the original initialization data. 

Easiest fix i could think of was to only allow the ui settings entires to invalidate their caches on update, as the actual data elements wiping their caches mid save seems to cause the issue.